### PR TITLE
relx compatibility

### DIFF
--- a/src/uri.app.src
+++ b/src/uri.app.src
@@ -2,6 +2,7 @@
  [{description, "URI Parsing/Encoding Library"}
   ,{vsn, "0.1.0"}
   ,{registered, []}
+  ,{modules, [uri, uri_defaults, uri_format, uri_parser]}
   ,{applications,
     [kernel
      ,stdlib


### PR DESCRIPTION
I tried to use your app within my one with no luck.
Here is the output of `relx`:

```
===> Application metadata file exists but is malformed: /home/vagrant/projects/erlang/erl_proxy/deps/uri/ebin/uri.app
```

I took a quick look at relx sources and found that `modules` option for app config is mandatory.
